### PR TITLE
Implement new pages and routing

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,14 +1,22 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link, Routes, Route } from "react-router-dom";
 import "./styles/home.css";
 import Particles from "./components/particles";
+import Contact from "./pages/contact";
+import Dashboard from "./pages/dashboard";
+import Extension from "./pages/extension";
+import Leaderboard from "./pages/leaderboard";
+import Showcase from "./pages/showcase";
 
 const navigation = [
     { name: "Explore", href: "/showcase" },
     { name: "Leaderboard", href: "/leaderboard" },
+    { name: "Dashboard", href: "/dashboard" },
+    { name: "Extension", href: "/extension" },
+    { name: "Contact", href: "/contact" },
 ];
 
-export default function Home() {
+function HomePage() {
     return (
         <div className="flex flex-col items-center justify-center w-screen h-screen overflow-hidden bg-gradient-to-tl via-zinc-600/20 to-black from-black">
             <nav className="my-16 animate-fade-in">
@@ -62,5 +70,18 @@ export default function Home() {
                 </Link>
             </div>
         </div>
+    );
+}
+
+export default function App() {
+    return (
+        <Routes>
+            <Route path="/" element={<HomePage />} />
+            <Route path="/contact" element={<Contact />} />
+            <Route path="/dashboard" element={<Dashboard />} />
+            <Route path="/extension" element={<Extension />} />
+            <Route path="/leaderboard" element={<Leaderboard />} />
+            <Route path="/showcase" element={<Showcase />} />
+        </Routes>
     );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,13 +2,13 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter as Router } from "react-router-dom";
 import "./index.css";
-import Home from "./App";
+import App from "./App";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
     <React.StrictMode>
         <Router>
-            <Home />
+            <App />
         </Router>
     </React.StrictMode>
 );

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -1,0 +1,38 @@
+import React from "react";
+
+export default function Contact() {
+    const contacts = [
+        {
+            title: "GitHub",
+            description: "View our code on GitHub",
+            href: "#", // placeholder
+        },
+        {
+            title: "Email",
+            description: "Send us an email",
+            href: "mailto:info@example.com",
+        },
+        {
+            title: "Discord",
+            description: "Join our Discord server",
+            href: "#",
+        },
+    ];
+
+    return (
+        <div className="min-h-screen flex items-center justify-center bg-zinc-900 py-10 text-white">
+            <div className="grid gap-6 sm:grid-cols-3 px-4">
+                {contacts.map((c) => (
+                    <a
+                        key={c.title}
+                        href={c.href}
+                        className="bg-zinc-800 rounded-lg shadow p-6 hover:shadow-lg transition duration-300"
+                    >
+                        <h3 className="text-lg font-semibold mb-2">{c.title}</h3>
+                        <p className="text-sm text-zinc-300">{c.description}</p>
+                    </a>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/src/pages/dashboard.js
+++ b/src/pages/dashboard.js
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from "react";
+
+export default function Dashboard() {
+    const [data, setData] = useState(null);
+
+    useEffect(() => {
+        // Placeholder API call to demonstrate MongoDB connection
+        fetch("/api/dashboard")
+            .then((res) => res.json())
+            .then((json) => setData(json))
+            .catch(() => {
+                // ignore errors for placeholder
+            });
+    }, []);
+
+    return (
+        <div className="min-h-screen bg-zinc-900 text-white p-8 space-y-6">
+            <h1 className="text-2xl font-bold">Dashboard</h1>
+            <div className="grid gap-6 md:grid-cols-3">
+                <div className="bg-zinc-800 rounded p-4">
+                    <h2 className="font-semibold mb-2">Coding Time</h2>
+                    <p>{data?.codingTime || "Loading..."}</p>
+                </div>
+                <div className="bg-zinc-800 rounded p-4">
+                    <h2 className="font-semibold mb-2">Commit Graph</h2>
+                    <p>Coming Soon</p>
+                </div>
+                <div className="bg-zinc-800 rounded p-4">
+                    <h2 className="font-semibold mb-2">Leaderboard Status</h2>
+                    <p>{data?.leaderboard || "Loading..."}</p>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/pages/extension.js
+++ b/src/pages/extension.js
@@ -1,0 +1,23 @@
+import React from "react";
+
+export default function Extension() {
+    const links = [
+        { label: "VSCode Extension", href: "#" },
+        { label: "Discord Bot", href: "#" },
+        { label: "GitHub Repository", href: "#" },
+    ];
+
+    return (
+        <div className="min-h-screen flex flex-col items-center justify-center bg-zinc-900 text-white space-y-4 p-8">
+            {links.map((l) => (
+                <a
+                    key={l.label}
+                    href={l.href}
+                    className="text-indigo-400 underline hover:text-indigo-300"
+                >
+                    {l.label}
+                </a>
+            ))}
+        </div>
+    );
+}

--- a/src/pages/leaderboard.js
+++ b/src/pages/leaderboard.js
@@ -1,0 +1,57 @@
+import React, { useState } from "react";
+import { Link } from "react-router-dom";
+
+const filters = ["All Time", "This Month", "This Week", "Today"];
+
+const sampleData = [
+    { username: "alice", time: "10h", change: 1 },
+    { username: "bob", time: "8h", change: 0 },
+    { username: "carol", time: "7h", change: -1 },
+];
+
+export default function Leaderboard() {
+    const [filter, setFilter] = useState(filters[0]);
+
+    return (
+        <div className="min-h-screen bg-zinc-900 text-white p-8 space-y-6">
+            <h1 className="text-2xl font-bold">Leaderboard</h1>
+            <div className="flex gap-4">
+                {filters.map((f) => (
+                    <button
+                        key={f}
+                        onClick={() => setFilter(f)}
+                        className={`px-3 py-1 rounded ${filter === f ? "bg-indigo-600" : "bg-zinc-800"}`}
+                    >
+                        {f}
+                    </button>
+                ))}
+            </div>
+            <table className="min-w-full divide-y divide-zinc-700">
+                <thead>
+                    <tr className="text-left">
+                        <th className="py-2">User</th>
+                        <th className="py-2">Time</th>
+                        <th className="py-2" />
+                    </tr>
+                </thead>
+                <tbody className="divide-y divide-zinc-800">
+                    {sampleData.map((row) => (
+                        <tr key={row.username}>
+                            <td className="py-2">
+                                <Link to={`/users/${row.username}`} className="text-indigo-400 hover:underline">
+                                    {row.username}
+                                </Link>
+                            </td>
+                            <td className="py-2">{row.time}</td>
+                            <td className="py-2">
+                                {row.change > 0 && <span className="text-green-500">↑</span>}
+                                {row.change < 0 && <span className="text-red-500">↓</span>}
+                                {row.change === 0 && <span className="text-gray-500">-</span>}
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}

--- a/src/pages/showcase.js
+++ b/src/pages/showcase.js
@@ -1,0 +1,33 @@
+import React from "react";
+
+export default function Showcase() {
+    const sections = [
+        {
+            title: "Use Cases",
+            content: "Track your coding time and share progress with friends.",
+        },
+        {
+            title: "Highlights",
+            content: "Detailed statistics and Discord integration for teams.",
+        },
+        {
+            title: "Future Plans",
+            content: "More analytics and cross-platform support coming soon.",
+        },
+    ];
+
+    return (
+        <div className="min-h-screen bg-zinc-900 text-white p-8 space-y-12">
+            {sections.map((s, i) => (
+                <div
+                    key={s.title}
+                    className="opacity-0 animate-fade-in"
+                    style={{ animationDelay: `${i * 200}ms` }}
+                >
+                    <h2 className="text-xl font-bold mb-2">{s.title}</h2>
+                    <p className="text-zinc-300">{s.content}</p>
+                </div>
+            ))}
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- build basic placeholder pages for contact, dashboard, extension, leaderboard and showcase
- configure React Router to include routes for each page
- expose the router via `App` and load it in `index.js`
- add navigation links for the new pages

## Testing
- `npm run lint`
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6882f1fd1a3c832db67e869291f4f573