### PR TITLE
Revamp contact and showcase pages

### DIFF
--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import Navbar from "../components/navbar";
 import Footer from "../components/footer";
 import Particles from "../components/particles";
@@ -7,8 +7,8 @@ export default function Contact() {
     const contacts = [
         {
             title: "GitHub",
-            description: "Contact via GitHub",
-            href: "https://www.github.com/JayNightmare",
+            description: "Join the GitHub discussions",
+            href: "https://github.com/JayNightmare/DisTrack-Website/discussions",
         },
         {
             title: "Email",
@@ -22,6 +22,51 @@ export default function Contact() {
         },
     ];
 
+    const [form, setForm] = useState({
+        name: "",
+        discord: "",
+        email: "",
+        reason: "",
+    });
+    const [status, setStatus] = useState("");
+    const webhookUrl =
+        "https://discord.com/api/webhooks/1403567130934251603/" +
+        "dDknPfsMv49uEwXEWXYqrfXYlwq6u3TIwguykT0mGg4genp9ojP1vyqqQ1wjYjnzR8Oc";
+
+    const handleChange = (e) => {
+        setForm({ ...form, [e.target.name]: e.target.value });
+    };
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setStatus("");
+        if (!form.discord) {
+            setStatus("Discord ID is required.");
+            return;
+        }
+
+        const content =
+            `**New Contact Submission**\n` +
+            `**Name:** ${form.name || "N/A"}\n` +
+            `**Discord ID:** ${form.discord}\n` +
+            `**Email:** ${form.email || "N/A"}\n` +
+            `**Reason:** ${form.reason}`;
+
+        try {
+            await fetch(webhookUrl, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ content }),
+            });
+            setStatus("Message sent! We'll get back to you soon.");
+            setForm({ name: "", discord: "", email: "", reason: "" });
+        } catch (err) {
+            setStatus("Failed to send message. Please try again later.");
+        }
+    };
+
     return (
         <div className="min-h-screen text-white p-8 space-y-6 bg-gradient-to-tl via-zinc-600/20 to-black from-black">
             <Navbar />
@@ -33,12 +78,60 @@ export default function Contact() {
                         href={c.href}
                         className="bg-zinc-800 rounded-lg shadow p-6 hover:shadow-lg transition duration-300"
                     >
-                        <h3 className="text-lg font-semibold mb-2">
-                            {c.title}
-                        </h3>
+                        <h3 className="text-lg font-semibold mb-2">{c.title}</h3>
                         <p className="text-sm text-zinc-300">{c.description}</p>
                     </a>
                 ))}
+            </div>
+            <div className="max-w-md mx-auto mt-8">
+                <p className="text-zinc-300 mb-4">
+                    Have a question or suggestion? Fill out the form below and
+                    we'll get back to you.
+                </p>
+                <form onSubmit={handleSubmit} className="space-y-4">
+                    <input
+                        type="text"
+                        name="name"
+                        value={form.name}
+                        onChange={handleChange}
+                        placeholder="Name"
+                        className="w-full p-2 rounded bg-zinc-700"
+                    />
+                    <input
+                        type="text"
+                        name="discord"
+                        value={form.discord}
+                        onChange={handleChange}
+                        placeholder="Discord ID *"
+                        required
+                        className="w-full p-2 rounded bg-zinc-700"
+                    />
+                    <input
+                        type="email"
+                        name="email"
+                        value={form.email}
+                        onChange={handleChange}
+                        placeholder="Email (optional)"
+                        className="w-full p-2 rounded bg-zinc-700"
+                    />
+                    <textarea
+                        name="reason"
+                        value={form.reason}
+                        onChange={handleChange}
+                        placeholder="Reason for contacting"
+                        required
+                        className="w-full p-2 rounded bg-zinc-700 h-32"
+                    />
+                    <button
+                        type="submit"
+                        className="w-full bg-blue-600 hover:bg-blue-700 rounded p-2"
+                    >
+                        Send
+                    </button>
+                    {status && (
+                        <p className="text-sm text-center text-zinc-300">{status}</p>
+                    )}
+                </form>
             </div>
             <Footer />
         </div>

--- a/src/pages/showcase.js
+++ b/src/pages/showcase.js
@@ -2,20 +2,71 @@ import React from "react";
 import Navbar from "../components/navbar";
 import Particles from "../components/particles";
 import Footer from "../components/footer";
+import { motion, AnimatePresence } from "framer-motion";
 
 export default function Showcase() {
+    const [openIndex, setOpenIndex] = React.useState(null);
+
+    const premiumFeatures = [
+        "Charts",
+        "Achievements",
+        "Advanced user profile",
+        "Extended Discord bot permissions",
+        "Unlimited goals",
+        "Unlimited teams",
+    ];
+
     const sections = [
         {
-            title: "Use Cases",
-            content: "Track your coding time and share progress with friends.",
+            title: "About Us",
+            content: (
+                <p className="text-zinc-300">
+                    DisTrack helps developers stay accountable by tracking coding activity and
+                    sharing progress with friends.
+                </p>
+            ),
         },
         {
-            title: "Highlights",
-            content: "Detailed statistics and Discord integration for teams.",
+            title: "Premium Features",
+            content: (
+                <ul className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-zinc-300">
+                    {premiumFeatures.map((f) => (
+                        <li
+                            key={f}
+                            className="bg-zinc-700/50 p-3 rounded-lg hover:bg-zinc-700 transition-colors"
+                        >
+                            {f}
+                        </li>
+                    ))}
+                </ul>
+            ),
         },
         {
-            title: "Future Plans",
-            content: "More analytics and cross-platform support coming soon.",
+            title: "What You Can Do",
+            content: (
+                <p className="text-zinc-300">
+                    Visualize your progress with interactive charts, track achievements, and manage
+                    as many teams and goals as you need with our premium tools.
+                </p>
+            ),
+        },
+        {
+            title: "Special Offer",
+            content: (
+                <p className="text-zinc-300">
+                    The first 100 people to sign up for premium will receive all future premium
+                    updates for free, provided they remain subscribed for at least 3 months.
+                </p>
+            ),
+        },
+        {
+            title: "Community Growth",
+            content: (
+                <p className="text-zinc-300">
+                    As our community grows, we plan to hold coding competitions and team based
+                    leaderboards.
+                </p>
+            ),
         },
     ];
 
@@ -23,16 +74,48 @@ export default function Showcase() {
         <div className="min-h-screen text-white p-8 space-y-6 bg-gradient-to-tl via-zinc-600/20 to-black from-black">
             <Navbar />
             <Particles className="absolute inset-0 -z-10" quantity={100} />
-            {sections.map((s, i) => (
-                <div
-                    key={s.title}
-                    className="opacity-0 animate-fade-in"
-                    style={{ animationDelay: `${i * 200}ms` }}
+
+            <section className="text-center mt-12 space-y-4">
+                <h1 className="text-4xl font-extrabold">Discover DisTrack</h1>
+                <p className="text-zinc-300 max-w-2xl mx-auto">
+                    Explore premium tools designed to keep you motivated and connected.
+                </p>
+                <a
+                    href="/login"
+                    className="inline-block bg-indigo-600 hover:bg-indigo-500 text-white px-6 py-3 rounded-lg transition-colors"
                 >
-                    <h2 className="text-xl font-bold mb-2">{s.title}</h2>
-                    <p className="text-zinc-300">{s.content}</p>
-                </div>
-            ))}
+                    Get Started
+                </a>
+            </section>
+
+            <div className="max-w-3xl mx-auto mt-8 space-y-4">
+                {sections.map((s, i) => (
+                    <div key={s.title} className="bg-zinc-800/50 rounded-lg overflow-hidden">
+                        <button
+                            type="button"
+                            onClick={() => setOpenIndex(openIndex === i ? null : i)}
+                            className="w-full flex justify-between items-center p-4 hover:bg-zinc-700/50 transition-colors"
+                        >
+                            <h2 className="text-xl font-bold">{s.title}</h2>
+                            <span className="text-2xl">{openIndex === i ? "−" : "+"}</span>
+                        </button>
+                        <AnimatePresence initial={false}>
+                            {openIndex === i && (
+                                <motion.div
+                                    initial={{ height: 0, opacity: 0 }}
+                                    animate={{ height: "auto", opacity: 1 }}
+                                    exit={{ height: 0, opacity: 0 }}
+                                    transition={{ duration: 0.3 }}
+                                    className="px-4 pb-4"
+                                >
+                                    {s.content}
+                                </motion.div>
+                            )}
+                        </AnimatePresence>
+                    </div>
+                ))}
+            </div>
+
             <Footer className="mt-8" />
         </div>
     );


### PR DESCRIPTION
## Summary
- Add Discord-integrated contact form with required Discord ID and optional email
- Link GitHub contact to project discussions
- Expand showcase with About Us, premium features, special offer, and community growth plans
- Style showcase page with hero section, feature cards, and interactive accordion

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896b565aa44832d8a0e716ab5249c15